### PR TITLE
feat: Support running GoReleaser on a Go project inside a subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ jobs:
 
 Following inputs can be used as `step.with` keys
 
-| Name          | Type    | Default   | Description                              |
-|---------------|---------|-----------|------------------------------------------|
-| `version`     | String  | `latest`  | GoReleaser version. Example: `v0.117.0`  |
-| `args`        | String  |           | Arguments to pass to GoReleaser          |
-| `key`         | String  |           | Private key to import                    |
+| Name          | Type    | Default   | Description                               |
+|---------------|---------|-----------|-------------------------------------------|
+| `version`     | String  | `latest`  | GoReleaser version. Example: `v0.117.0`   |
+| `args`        | String  |           | Arguments to pass to GoReleaser           |
+| `key`         | String  |           | Private key to import                     |
+| `workdir`     | String  | `.`       | Working directory (below repository root) |
 
 ### Signing
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
     description: 'Arguments to pass to GoReleaser'
   key:
     description: 'Private key to import'
+  workdir:
+    description: 'Working directory (below repository root)'
+    default: '.'
 
 runs:
   using: 'node12'

--- a/lib/main.js
+++ b/lib/main.js
@@ -26,7 +26,12 @@ function run(silent) {
             const version = core.getInput('version') || 'latest';
             const args = core.getInput('args');
             const key = core.getInput('key');
+            const workdir = core.getInput('workdir') || '.';
             const goreleaser = yield installer.getGoReleaser(version);
+            if (workdir && workdir !== '.') {
+                console.log(`📂 Using ${workdir} as working directory...`);
+                process.chdir(workdir);
+            }
             let snapshot = '';
             if (!process.env.GITHUB_REF || !process.env.GITHUB_REF.startsWith('refs/tags/')) {
                 console.log(`⚠️ No tag found. Snapshot forced`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,13 @@ export async function run(silent?: boolean) {
     const version = core.getInput('version') || 'latest';
     const args = core.getInput('args');
     const key = core.getInput('key');
+    const workdir = core.getInput('workdir') || '.';
     const goreleaser = await installer.getGoReleaser(version);
+
+    if (workdir && workdir !== '.') {
+      console.log(`📂 Using ${workdir} as working directory...`)
+      process.chdir(workdir);
+    }
 
     let snapshot = '';
     if (!process.env.GITHUB_REF || !process.env.GITHUB_REF.startsWith('refs/tags/')) {


### PR DESCRIPTION
Sometimes you might be running a repository which needs to have the go projected rooted in a subdirectory (e.g. a mono-repo with code in multiple languages).

In this case, you can't just use `args` to specify a configuration file inside the sub-directory, since Go will still search for the module definition (or the `vendor/` directory) in the current working directory from which GoReleaser is run - which happens to be the repository's root directory.

This PR simply adds a new input (`subdir`) that allows you to specify a subdirectory under the repository root.