### PR TITLE
feat: support non-tag push event trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,4 +40,4 @@ jobs:
         uses: ./
         with:
           version: ${{ matrix.version }}
-          args: release --skip-publish --rm-dist
+          args: release --skip-publish --rm-dist --snapshot

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Following inputs can be used as `step.with` keys
 | `args`        | String  |           | Arguments to pass to GoReleaser           |
 | `key`         | String  |           | Private key to import                     |
 | `workdir`     | String  | `.`       | Working directory (below repository root) |
+| `skip_snapshot_check`     | Boolean  | `false`       | Do not use --snapshot regardless of environment variables if true. |
 
 ### Signing
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Below is a simple snippet to use this action. A [live example](https://github.co
 name: goreleaser
 
 on:
-  pull_request:
   push:
+    tags:
+    - '*'
 
 jobs:
   goreleaser:
@@ -52,31 +53,8 @@ jobs:
 
 > **IMPORTANT**: note the `Unshallow` step. It is required for the changelog to work correctly.
 
-If you want to run GoReleaser only on new tag, you can use this event:
-
-```yaml
-on:
-  push:
-    tags:
-      - '*'
-```
-
-Or with a condition on GoReleaser step:
-
-```yaml
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          version: latest
-          args: release --rm-dist
-          key: ${{ secrets.YOUR_PRIVATE_KEY }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-> For detailed instructions please follow GitHub Actions [workflow syntax](https://help.github.com/en/articles/workflow-syntax-for-github-actions#About-yaml-syntax-for-workflows).
+> If you want to run GoReleaser on non-tag push to generate an unversioned
+> snapshot release, use `args: release --snapshot`.
 
 ## Customizing
 
@@ -90,7 +68,6 @@ Following inputs can be used as `step.with` keys
 | `args`        | String  |           | Arguments to pass to GoReleaser           |
 | `key`         | String  |           | Private key to import                     |
 | `workdir`     | String  | `.`       | Working directory (below repository root) |
-| `skip_snapshot_check`     | Boolean  | `false`       | Do not use --snapshot regardless of environment variables if true. |
 
 ### Signing
 

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,6 @@ inputs:
   workdir:
     description: 'Working directory (below repository root)'
     default: '.'
-  skip_snapshot_check:
-    description: 'Do not use --snapshot regardless of environment variables if true.'
 
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
   workdir:
     description: 'Working directory (below repository root)'
     default: '.'
+  skip_snapshot_check:
+    description: 'Do not use --snapshot regardless of environment variables if true.'
 
 runs:
   using: 'node12'

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,20 +27,26 @@ function run(silent) {
             const args = core.getInput('args');
             const key = core.getInput('key');
             const workdir = core.getInput('workdir') || '.';
+            const skipSnapshotCheck = core.getInput('skip_snapshot_check') === 'true';
             const goreleaser = yield installer.getGoReleaser(version);
             if (workdir && workdir !== '.') {
                 console.log(`📂 Using ${workdir} as working directory...`);
                 process.chdir(workdir);
             }
             let snapshot = '';
-            if (!process.env.GITHUB_REF || !process.env.GITHUB_REF.startsWith('refs/tags/')) {
-                console.log(`⚠️ No tag found. Snapshot forced`);
-                if (!args.includes('--snapshot')) {
-                    snapshot = ' --snapshot';
-                }
+            if (skipSnapshotCheck) {
+                console.log(`✅ --snapshot check is skipped`);
             }
             else {
-                console.log(`✅ ${process.env.GITHUB_REF.split('/')[2]} tag found`);
+                if (!process.env.GITHUB_REF || !process.env.GITHUB_REF.startsWith('refs/tags/')) {
+                    console.log(`⚠️ No tag found. Snapshot forced`);
+                    if (!args.includes('--snapshot')) {
+                        snapshot = ' --snapshot';
+                    }
+                }
+                else {
+                    console.log(`✅ ${process.env.GITHUB_REF.split('/')[2]} tag found`);
+                }
             }
             if (key) {
                 console.log('🔑 Importing signing key...');

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,26 +27,10 @@ function run(silent) {
             const args = core.getInput('args');
             const key = core.getInput('key');
             const workdir = core.getInput('workdir') || '.';
-            const skipSnapshotCheck = core.getInput('skip_snapshot_check') === 'true';
             const goreleaser = yield installer.getGoReleaser(version);
             if (workdir && workdir !== '.') {
                 console.log(`📂 Using ${workdir} as working directory...`);
                 process.chdir(workdir);
-            }
-            let snapshot = '';
-            if (skipSnapshotCheck) {
-                console.log(`✅ --snapshot check is skipped`);
-            }
-            else {
-                if (!process.env.GITHUB_REF || !process.env.GITHUB_REF.startsWith('refs/tags/')) {
-                    console.log(`⚠️ No tag found. Snapshot forced`);
-                    if (!args.includes('--snapshot')) {
-                        snapshot = ' --snapshot';
-                    }
-                }
-                else {
-                    console.log(`✅ ${process.env.GITHUB_REF.split('/')[2]} tag found`);
-                }
             }
             if (key) {
                 console.log('🔑 Importing signing key...');
@@ -57,7 +41,7 @@ function run(silent) {
                 });
             }
             console.log('🏃 Running GoReleaser...');
-            yield exec.exec(`${goreleaser} ${args}${snapshot}`, undefined, {
+            yield exec.exec(`${goreleaser} ${args}`, undefined, {
                 silent: silent
             });
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,21 +9,26 @@ export async function run(silent?: boolean) {
     const args = core.getInput('args');
     const key = core.getInput('key');
     const workdir = core.getInput('workdir') || '.';
+    const skipSnapshotCheck = core.getInput('skip_snapshot_check') === 'true';
     const goreleaser = await installer.getGoReleaser(version);
 
     if (workdir && workdir !== '.') {
-      console.log(`📂 Using ${workdir} as working directory...`)
+      console.log(`📂 Using ${workdir} as working directory...`);
       process.chdir(workdir);
     }
 
     let snapshot = '';
-    if (!process.env.GITHUB_REF || !process.env.GITHUB_REF.startsWith('refs/tags/')) {
-      console.log(`⚠️ No tag found. Snapshot forced`);
-      if (!args.includes('--snapshot')) {
-        snapshot = ' --snapshot';
-      }
+    if (skipSnapshotCheck) {
+      console.log(`✅ --snapshot check is skipped`);
     } else {
-      console.log(`✅ ${process.env.GITHUB_REF!.split('/')[2]} tag found`);
+      if (!process.env.GITHUB_REF || !process.env.GITHUB_REF.startsWith('refs/tags/')) {
+        console.log(`⚠️ No tag found. Snapshot forced`);
+        if (!args.includes('--snapshot')) {
+          snapshot = ' --snapshot';
+        }
+      } else {
+        console.log(`✅ ${process.env.GITHUB_REF!.split('/')[2]} tag found`);
+      }
     }
 
     if (key) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,26 +9,11 @@ export async function run(silent?: boolean) {
     const args = core.getInput('args');
     const key = core.getInput('key');
     const workdir = core.getInput('workdir') || '.';
-    const skipSnapshotCheck = core.getInput('skip_snapshot_check') === 'true';
     const goreleaser = await installer.getGoReleaser(version);
 
     if (workdir && workdir !== '.') {
       console.log(`📂 Using ${workdir} as working directory...`);
       process.chdir(workdir);
-    }
-
-    let snapshot = '';
-    if (skipSnapshotCheck) {
-      console.log(`✅ --snapshot check is skipped`);
-    } else {
-      if (!process.env.GITHUB_REF || !process.env.GITHUB_REF.startsWith('refs/tags/')) {
-        console.log(`⚠️ No tag found. Snapshot forced`);
-        if (!args.includes('--snapshot')) {
-          snapshot = ' --snapshot';
-        }
-      } else {
-        console.log(`✅ ${process.env.GITHUB_REF!.split('/')[2]} tag found`);
-      }
     }
 
     if (key) {
@@ -41,7 +26,7 @@ export async function run(silent?: boolean) {
     }
 
     console.log('🏃 Running GoReleaser...');
-    await exec.exec(`${goreleaser} ${args}${snapshot}`, undefined, {
+    await exec.exec(`${goreleaser} ${args}`, undefined, {
       silent: silent
     });
   } catch (error) {


### PR DESCRIPTION
It supports usecases that users manually tag new version with GitHub
Actions workflow, and then release it.

e.g. https://github.com/actions/create-release support `tag` input and
can be used for non tag push event.