### PR TITLE
Add push to master specification in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ name: goreleaser
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   goreleaser:
@@ -69,6 +71,8 @@ If you want to run GoReleaser only on new tag, you can use this event:
 ```yaml
 on:
   push:
+    branches:
+      - master
     tags:
       - '*'
 ```


### PR DESCRIPTION
To ensure that a dev branch isn't pushed I changed the docs to tell users to run the action only on pushes to the master branch. Thank you!