### PR TITLE
fix: Use GITHUB_REF to retrieve tag

### DIFF
--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -3,6 +3,7 @@ import * as git from '../src/git';
 describe('git', () => {
   it('returns git tag', async () => {
     const tag: string = await git.getTag();
+    console.log(`tag: ${tag}`);
     expect(tag).not.toEqual('');
   });
   it('checks if tag is dirty', async () => {
@@ -10,6 +11,7 @@ describe('git', () => {
   });
   it('returns short commit', async () => {
     const commit: string = await git.getShortCommit();
+    console.log(`commit: ${commit}`);
     expect(commit).not.toEqual('');
   });
 });

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -2,12 +2,19 @@ import * as git from '../src/git';
 
 describe('git', () => {
   it('returns git tag through describe', async () => {
+    process.env.GITHUB_SHA = '309312125ed7a32fcd48f3a1e24dcafe669c186a';
     const tag: string = await git.getTag();
     console.log(`tag: ${tag}`);
     expect(tag).not.toEqual('');
   });
+  it('returns git tag through GITHUB_SHA', async () => {
+    process.env.GITHUB_SHA = '6e37040623d14330555c7be1603a9182cf92d32a';
+    const tag: string = await git.getTag();
+    console.log(`tag: ${tag}`);
+    expect(tag).toEqual('v1');
+  });
   it('returns git tag through GITHUB_REF', async () => {
-    process.env.GITHUB_REF = 'refs/tags/v2.2.1'
+    process.env.GITHUB_REF = 'refs/tags/v2.2.1';
     const tag: string = await git.getTag();
     console.log(`tag: ${tag}`);
     expect(tag).toEqual('v2.2.1');

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -1,10 +1,16 @@
 import * as git from '../src/git';
 
 describe('git', () => {
-  it('returns git tag', async () => {
+  it('returns git tag through describe', async () => {
     const tag: string = await git.getTag();
     console.log(`tag: ${tag}`);
     expect(tag).not.toEqual('');
+  });
+  it('returns git tag through GITHUB_REF', async () => {
+    process.env.GITHUB_REF = 'refs/tags/v2.2.1'
+    const tag: string = await git.getTag();
+    console.log(`tag: ${tag}`);
+    expect(tag).toEqual('v2.2.1');
   });
   it('checks if tag is dirty', async () => {
     expect(await git.isTagDirty('v1.3.1')).toBe(true);

--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -5,6 +5,7 @@ describe('github', () => {
     const release = await github.getRelease('latest');
     expect(release).not.toBeNull();
     expect(release?.tag_name).not.toEqual('');
+    console.log(`tag_name: ${release?.tag_name}`);
   });
   it('returns v0.117.0 GoReleaser GitHub release', async () => {
     const release = await github.getRelease('v0.117.0');

--- a/dist/index.js
+++ b/dist/index.js
@@ -1803,7 +1803,12 @@ function getTag() {
                     return tag;
                 }
             }
-            return yield git(['describe', '--tags', '--abbrev=0']);
+            return yield git(['tag', '--points-at', `${process.env.GITHUB_SHA}`, '--sort', '-version:creatordate']).then(tags => {
+                if (tags.split('\n').length == 0) {
+                    return git(['describe', '--tags', '--abbrev=0']);
+                }
+                return tags.split('\n')[0];
+            });
         }
         catch (err) {
             return '';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1804,7 +1804,7 @@ function getTag() {
                 }
             }
             return yield git(['tag', '--points-at', `${process.env.GITHUB_SHA}`, '--sort', '-version:creatordate']).then(tags => {
-                if (tags.split('\n').length == 0) {
+                if (tags.length == 0) {
                     return git(['describe', '--tags', '--abbrev=0']);
                 }
                 return tags.split('\n')[0];

--- a/dist/index.js
+++ b/dist/index.js
@@ -1797,6 +1797,12 @@ const git = (args = []) => __awaiter(void 0, void 0, void 0, function* () {
 function getTag() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            if ((process.env.GITHUB_REF || '').startsWith('refs/tags')) {
+                const tag = (process.env.GITHUB_REF || '').split('/').pop();
+                if (tag !== '' && tag !== undefined) {
+                    return tag;
+                }
+            }
             return yield git(['describe', '--tags', '--abbrev=0']);
         }
         catch (err) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -11,6 +11,12 @@ const git = async (args: string[] = []): Promise<string> => {
 
 export async function getTag(): Promise<string> {
   try {
+    if ((process.env.GITHUB_REF || '').startsWith('refs/tags')) {
+      const tag = (process.env.GITHUB_REF || '').split('/').pop();
+      if (tag !== '' && tag !== undefined) {
+        return tag;
+      }
+    }
     return await git(['describe', '--tags', '--abbrev=0']);
   } catch (err) {
     return '';

--- a/src/git.ts
+++ b/src/git.ts
@@ -19,7 +19,7 @@ export async function getTag(): Promise<string> {
     }
     return await git(['tag', '--points-at', `${process.env.GITHUB_SHA}`, '--sort', '-version:creatordate']).then(
       tags => {
-        if (tags.split('\n').length == 0) {
+        if (tags.length == 0) {
           return git(['describe', '--tags', '--abbrev=0']);
         }
         return tags.split('\n')[0];

--- a/src/git.ts
+++ b/src/git.ts
@@ -17,7 +17,14 @@ export async function getTag(): Promise<string> {
         return tag;
       }
     }
-    return await git(['describe', '--tags', '--abbrev=0']);
+    return await git(['tag', '--points-at', `${process.env.GITHUB_SHA}`, '--sort', '-version:creatordate']).then(
+      tags => {
+        if (tags.split('\n').length == 0) {
+          return git(['describe', '--tags', '--abbrev=0']);
+        }
+        return tags.split('\n')[0];
+      }
+    );
   } catch (err) {
     return '';
   }


### PR DESCRIPTION
Closes #238 

Use `GITHUB_REF` to retrieve tag before checking the most recent tag.