### PR TITLE
Add install-only option for using goreleaser in user scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ___
   * [Workflow](#workflow)
   * [Run on new tag](#run-on-new-tag)
   * [Signing](#signing)
+  * [Install Only](#install-only)
 * [Customizing](#customizing)
   * [inputs](#inputs)
   * [environment variables](#environment-variables)
@@ -120,6 +121,20 @@ signs:
     args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
 ```
 
+### Install Only
+
+```yaml
+steps:
+  -
+    name: Install GoReleaser
+    uses: goreleaser/goreleaser-action@v2
+    with:
+      install-only: true
+  -
+    name: Show GoReleaser version
+    run: goreleaser -v
+```
+
 ## Customizing
 
 ### inputs
@@ -131,6 +146,7 @@ Following inputs can be used as `step.with` keys
 | `version`**¹**   | String  | `latest`  | GoReleaser version                        |
 | `args`           | String  |           | Arguments to pass to GoReleaser           |
 | `workdir`        | String  | `.`       | Working directory (below repository root) |
+| `install-only`   | Bool    | `false`   | Just install GoReleaser                   |
 
 > **¹** Can be a fixed version like `v0.117.0` or a max satisfying semver one like `~> 0.132`. In this case this will return `v0.132.1`.
 

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,13 @@ inputs:
     description: 'GoReleaser version'
     default: 'latest'
     required: false
+  install-only:
+    description: 'Just install GoReleaser'
+    default: 'false'
+    required: false
   args:
     description: 'Arguments to pass to GoReleaser'
-    required: true
+    required: true # not required when install-only=true
   workdir:
     description: 'Working directory (below repository root)'
     default: '.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -339,13 +339,22 @@ const git = __importStar(__webpack_require__(374));
 const installer = __importStar(__webpack_require__(480));
 const core = __importStar(__webpack_require__(186));
 const exec = __importStar(__webpack_require__(514));
+const path_1 = __webpack_require__(622);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const version = core.getInput('version') || 'latest';
-            const args = core.getInput('args', { required: true });
+            const isInstallOnly = /^true$/i.test(core.getInput('install-only'));
             const workdir = core.getInput('workdir') || '.';
             const goreleaser = yield installer.getGoReleaser(version);
+            core.info(`✅ GoReleaser installed successfully`);
+            if (isInstallOnly) {
+                const goreleaserDir = path_1.dirname(goreleaser);
+                core.addPath(goreleaserDir);
+                core.debug(`Added ${goreleaserDir} to PATH`);
+                return;
+            }
+            const args = core.getInput('args', { required: true });
             if (workdir && workdir !== '.') {
                 core.info(`📂 Using ${workdir} as working directory...`);
                 process.chdir(workdir);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,22 @@ import * as git from './git';
 import * as installer from './installer';
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
+import {dirname} from 'path';
 
 async function run(): Promise<void> {
   try {
     const version = core.getInput('version') || 'latest';
-    const args = core.getInput('args', {required: true});
+    const isInstallOnly = /^true$/i.test(core.getInput('install-only'));
     const workdir = core.getInput('workdir') || '.';
     const goreleaser = await installer.getGoReleaser(version);
+    core.info(`✅ GoReleaser installed successfully`);
+    if (isInstallOnly) {
+      const goreleaserDir = dirname(goreleaser);
+      core.addPath(goreleaserDir);
+      core.debug(`Added ${goreleaserDir} to PATH`);
+      return;
+    }
+    const args = core.getInput('args', {required: true});
 
     if (workdir && workdir !== '.') {
       core.info(`📂 Using ${workdir} as working directory...`);


### PR DESCRIPTION
Closes #250 

Added `install-only` option that installs GoReleaser, add it to `PATH` and exits. In the subsequent steps users can consume `goreleaser` CLI.


 