### PR TITLE
chore: node 16 as default runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,5 +34,5 @@ outputs:
     description: 'Build result metadata'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG NODE_VERSION=12
+ARG NODE_VERSION=16
 
 FROM node:${NODE_VERSION}-alpine AS base
 RUN apk add --no-cache cpio findutils git


### PR DESCRIPTION
keeping in draft for now as it requires a major bump of the action to avoid breaking users that are still on runners that do not support node 16:

> This change adds a minimum runner version(node12 -> node16), which can break users using an out-of-date/fork of the runner. This would be most commonly affecting users on GHES 3.3 or before, as those runners do not support node16 actions and they can use actions from github.com via github connect or manually copying the repo to their GHES instance.

See https://github.com/actions/cache/releases/tag/v3.0.0