### PR TITLE
ci: fix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,4 +195,4 @@ jobs:
           args: release --skip-publish --rm-dist
           workdir: ./test
         env:
-          GORELEASER_CURRENT_TAG: v1.2.3
+          GORELEASER_CURRENT_TAG: v99.99.99


### PR DESCRIPTION
encounter this error while releasing v3.0.0:

```
v3.0.0 tag found for commit '68acf3b'
/opt/hostedtoolcache/goreleaser-action/1.9.1/x64/goreleaser release --skip-publish --rm-dist
   • releasing...     
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • couldn't find any tags before "v1.2.3"
      • building...               commit=68acf3b1adf004ac9c2f0a4259e85c5f66e99bef latest tag=v1.2.3
   ⨯ release failed after 0.03s error=git tag v1.2.3 was not made against commit 68acf3b1adf004ac9c2f0a4259e85c5f66e99bef
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.9.1/x64/goreleaser' failed with exit code 1
```

that's because `v1.2.3` already exists in the working tree.