### PR TITLE
Update Readme to reference `goreleaser/goreleaser-action@v4`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-go@v3
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
@@ -83,7 +83,7 @@ Or with a condition on GoReleaser step:
 ```yaml
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         if: startsWith(github.ref, 'refs/tags/')
         with:
           version: latest
@@ -109,7 +109,7 @@ the [Import GPG](https://github.com/crazy-max/ghaction-import-gpg) GitHub Action
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release --rm-dist
@@ -134,7 +134,7 @@ purpose. You can do that with the [actions/upload-artifact](https://github.com/a
 ```yaml
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release --rm-dist
@@ -155,7 +155,7 @@ purpose. You can do that with the [actions/upload-artifact](https://github.com/a
 steps:
   -
     name: Install GoReleaser
-    uses: goreleaser/goreleaser-action@v3
+    uses: goreleaser/goreleaser-action@v4
     with:
       install-only: true
   -
@@ -209,7 +209,7 @@ secret named `GH_PAT`, the step will look like this:
 ```yaml
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Hi, I noticed the examples were not updated after the release of v4.
If they are all still compatible with v3, could we update them like this?