### PR TITLE
Update in command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,20 @@ ___
 
 ![GoRelease Action](.github/goreleaser-action.png)
 
-* [Usage](#usage)
-  * [Workflow](#workflow)
-  * [Run on new tag](#run-on-new-tag)
-  * [Signing](#signing)
-  * [Upload artifacts](#upload-artifacts)
-  * [Install Only](#install-only)
-* [Customizing](#customizing)
-  * [inputs](#inputs)
-  * [outputs](#outputs)
-  * [environment variables](#environment-variables)
-* [Limitation](#limitation)
-* [Development](#development)
-* [License](#license)
+- [Usage](#usage)
+  - [Workflow](#workflow)
+  - [Run on new tag](#run-on-new-tag)
+  - [Signing](#signing)
+  - [Upload artifacts](#upload-artifacts)
+  - [Install Only](#install-only)
+- [Customizing](#customizing)
+  - [inputs](#inputs)
+  - [outputs](#outputs)
+  - [environment variables](#environment-variables)
+- [Limitation](#limitation)
+- [Migrating from v3](#migrating-from-v3)
+- [Development](#development)
+- [License](#license)
 
 ## Usage
 
@@ -58,7 +59,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
@@ -87,7 +88,7 @@ Or with a condition on GoReleaser step:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -112,7 +113,7 @@ the [Import GPG](https://github.com/crazy-max/ghaction-import-gpg) GitHub Action
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
@@ -137,7 +138,7 @@ purpose. You can do that with the [actions/upload-artifact](https://github.com/a
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
           workdir: myfolder
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -212,7 +213,7 @@ secret named `GH_PAT`, the step will look like this:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ ___
 * [Development](#development)
 * [License](#license)
 
-
 ## Usage
 
 ### Workflow

--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ ___
 
 ![GoRelease Action](.github/goreleaser-action.png)
 
-- [Usage](#usage)
-  - [Workflow](#workflow)
-  - [Run on new tag](#run-on-new-tag)
-  - [Signing](#signing)
-  - [Upload artifacts](#upload-artifacts)
-  - [Install Only](#install-only)
-- [Customizing](#customizing)
-  - [inputs](#inputs)
-  - [outputs](#outputs)
-  - [environment variables](#environment-variables)
-- [Limitation](#limitation)
-- [Migrating from v3](#migrating-from-v3)
-- [Development](#development)
-- [License](#license)
+* [Usage](#usage)
+  * [Workflow](#workflow)
+  * [Run on new tag](#run-on-new-tag)
+  * [Signing](#signing)
+  * [Upload artifacts](#upload-artifacts)
+  * [Install Only](#install-only)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+  * [outputs](#outputs)
+  * [environment variables](#environment-variables)
+* [Limitation](#limitation)
+* [Development](#development)
+* [License](#license)
+
 
 ## Usage
 


### PR DESCRIPTION
In the command/setup example, it is mentioned `--rm-dist`. 

However, this is deprecated as per the [doc](https://goreleaser.com/deprecations/#-rm-dist).

I just replaced it by the recommended `--clean`